### PR TITLE
Class rex_navbuilder getStructure

### DIFF
--- a/lib/rex_navbuilder.php
+++ b/lib/rex_navbuilder.php
@@ -42,4 +42,74 @@ class rex_navbuilder
         }
         return '<ul class="rex-navi-depth-' . $depth . '">' . $list . '</ul>';
     }
+
+      /**
+     * get the raw structure of nav $name
+     * 
+     * @param string $name
+     * 
+     * @return array
+     */
+
+    public static function getStructure($name) {
+
+        $menu = rex_navbuilder_navigation::query()
+            ->select('id')
+            ->where('name', $name)
+            ->orderBy('id')
+            ->findOne();
+
+        $items = json_decode($menu->structure, true);
+       
+        return self::buildStructure($items);
+    }
+
+    /**
+     * builds a raw nav of $items
+     * 
+     * @param array $items
+     * 
+     * @return array
+     */
+
+    private static function buildStructure($items) {
+        $list = [];
+
+        foreach ($items as $item):
+
+
+            $children = [];
+
+            if (!empty($item['children'])) {
+                $children = self::buildStructure($item['children']);
+            }
+
+            $data = [
+                "type" => $item["type"],
+                "children" => $children
+            ];
+
+            if ($item['type'] == 'intern' && rex_article::get($item["href"]) ){
+                
+                $data["id"] = $item["href"];
+                $data["active"] = $item["href"] == rex_article::getCurrentId();
+                $data["name"] = rex_article::get($item["href"])->getName();
+
+            } else if ($item['type'] == 'extern') {
+
+                $data["name"] = $item["text"];
+                $data["href"] = $item["href"];
+
+            } else if ($item['type'] == 'group') {
+
+                $data["name"] = $item["text"];
+
+            }
+
+            $list[] = $data;
+        
+        endforeach;
+
+        return $list;
+    }
 }


### PR DESCRIPTION
In diesem Pull Request geht es darum, Funktionen zur Klasse rex_navbuilder hinzuzufügen, damit User ihre Navigation selbst erstellen können. 

Problem:
- rex_navbuilder::get($name): gibt festgelegtes HTML zurück

Lösung:
- rex_navbuilder::getStructure($name): gibt die Navigation als Array zurück
- HTML kann so selbst erstellt werden